### PR TITLE
basic german

### DIFF
--- a/kindle2notion/languages/enums.py
+++ b/kindle2notion/languages/enums.py
@@ -5,33 +5,43 @@ class Locale(Enum):
     # Enum containing languages
     ENGLISH = "en"
     SPANISH = "es"
+    GERMAN = "de"
 
     def __str__(self):
         return self.value
+    
+    @classmethod
+    def list(cls):
+        return list(map(lambda c: c.value, cls))
 
 
 class Word(Enum):
     # For each word, we have to handle different languages
     NOTE = {
         Locale.ENGLISH: "note",
-        Locale.SPANISH: "nota"
+        Locale.SPANISH: "nota",
+        Locale.GERMAN: "Notiz",
     }
     LOCATION = {
         Locale.ENGLISH: "location",
         Locale.SPANISH: "posición",
+        Locale.GERMAN: "Position",
     }
     PAGE = {
         Locale.ENGLISH: "page",
         Locale.SPANISH: "página",
+        Locale.GERMAN: "Seite",
     }
     DATE_ADDED = {
         Locale.ENGLISH: "added on",
         Locale.SPANISH: "añadido el",
+        Locale.GERMAN: "Hinzugefügt am",
     }
     # Date formats also depend on language
     DATE_FORMAT = {
-        Locale.ENGLISH: "%A, %d %B %Y %I:%M:%S %p",
+        Locale.ENGLISH: "%A, %B %d, %Y %I:%M:%S %p",
         Locale.SPANISH: "%A, %d %B %Y %H:%M:%S",
+        Locale.GERMAN: "%A, %d. %B %Y %H:%M:%S",
     }
 
     def __str__(self, language=Locale.ENGLISH):

--- a/kindle2notion/reading.py
+++ b/kindle2notion/reading.py
@@ -5,11 +5,8 @@ def read_raw_clippings(clippings_file_path: Path) -> str:
     try:
         with open(clippings_file_path, "r", encoding="utf-8-sig") as raw_clippings_file:
             raw_clippings_text = raw_clippings_file.read()
-        raw_clippings_text = raw_clippings_text.replace(u"\ufeff", "")
-        raw_clippings_text_decoded = raw_clippings_text.encode(
-            "ascii", errors="ignore"
-        ).decode()
     except UnicodeEncodeError as e:
         print(e)
 
-    return raw_clippings_text_decoded
+    print(raw_clippings_text)
+    return raw_clippings_text

--- a/tests/test_data/de_DE-test.txt
+++ b/tests/test_data/de_DE-test.txt
@@ -1,0 +1,5 @@
+﻿Range (David Epstein)
+- Deine Markierung auf Seite 27 | bei Position 442-442 | Hinzugefügt am Montag, 13. November 2023 23:30:15
+
+It took Treffert decades to realize he had been wrong,
+==========

--- a/tests/test_data/en_US-test.txt
+++ b/tests/test_data/en_US-test.txt
@@ -1,0 +1,5 @@
+Range (David Epstein)
+- Your Highlight on page 92 | Location 1381-1385 | Added on Friday, November 17, 2023 6:54:38 PM
+
+Psychologist Robert Bjork first used the phrase desirable difficulties in 1994.
+==========


### PR DESCRIPTION
- adds german strings
- remove unnecessary ascii encode/decode that kills german umlauts
- adds minimal test clippings for `en_US` and `de_DE`